### PR TITLE
remove DICP submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -154,6 +154,3 @@
 [submodule "third_party/cutlass"]
 	path = third_party/cutlass
 	url = https://github.com/NVIDIA/cutlass.git
-[submodule "third_party/DICP"]
-	path = third_party/DICP
-	url = git@github.com:OpenComputeLab/DICP.git

--- a/torch/_dynamo/backends/ascendgraph.py
+++ b/torch/_dynamo/backends/ascendgraph.py
@@ -1,8 +1,0 @@
-from torch._dynamo import register_backend
-
-
-@register_backend
-def ascendgraph(gm, fake_input_tensor):
-    from third_party.DICP.common.compile_fx import compile_fx
-
-    return compile_fx(gm, fake_input_tensor, "ascendgraph")

--- a/torch/_dynamo/backends/topsgraph.py
+++ b/torch/_dynamo/backends/topsgraph.py
@@ -1,8 +1,0 @@
-from torch._dynamo import register_backend
-
-
-@register_backend
-def topsgraph(gm, fake_input_tensor):
-    from third_party.DICP.common.compile_fx import compile_fx
-
-    return compile_fx(gm, fake_input_tensor, "topsgraph")


### PR DESCRIPTION
we can remove the dependency of DICP in pytorch repo due to the usage of entry_points in torch_dynamo_backends
https://github.com/DeepLink-org/pytorch/blob/17c0b1c298a1bf79443c9fe9acfad47381e09121/torch/_dynamo/backends/registry.py#L92-L109